### PR TITLE
fix: VaultService.List will now get ALL records, not just the first p…

### DIFF
--- a/model/range.go
+++ b/model/range.go
@@ -1,0 +1,99 @@
+package model
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+)
+
+const (
+	HEADER_REQ_RANGE  = "Range"
+	HEADER_COUNT_MODE = "topicus-Range-Count"
+	HEADER_RESP_RANGE = "Content-Range"
+	RANGE_PER_PAGE    = 100
+)
+
+var contentRangeRegex *regexp.Regexp
+
+func NewRange() *Range {
+
+	if contentRangeRegex == nil {
+		contentRangeRegex, _ = regexp.Compile("items (\\d+)-(\\d+)/(\\d+)")
+	}
+
+	r := &Range{}
+	r.Setup(RANGE_PER_PAGE)
+
+	return r
+}
+
+type Range struct {
+	start   int
+	end     int
+	total   int
+	perpage int
+}
+
+func (r *Range) Setup(perpage int) {
+	r.start = 0
+	r.end = perpage - 1
+	r.total = perpage
+	r.perpage = perpage
+}
+
+func (r *Range) ParseResponse(response *http.Response) {
+
+	if response == nil {
+		// Reset to page 1
+		r.Setup(r.perpage)
+	}
+
+	matches := contentRangeRegex.FindStringSubmatch(response.Header.Get(HEADER_RESP_RANGE))
+	// matches[0]  = all, matches[1]  = start (0 based), matches[2]  = end (0 based), matches[3]  = total
+
+	if len(matches) > 0 {
+		r.start, _ = strconv.Atoi(matches[1])
+		r.end, _ = strconv.Atoi(matches[2])
+		r.total, _ = strconv.Atoi(matches[3])
+	}
+
+}
+
+func (r *Range) NextPage() bool {
+
+	if r.end+1 >= r.total {
+		return false
+	}
+
+	r.start = r.end + 1
+	r.end = r.start + r.perpage
+
+	return true
+}
+
+func (r *Range) PreviousPage() bool {
+
+	if r.start <= 0 {
+		return false
+	}
+
+	r.end = r.start - 1
+	r.start = r.end - r.perpage
+
+	// If start gets lower than 0, reset to page 0 values
+	if r.start < 0 {
+		r.Setup(r.perpage)
+	}
+
+	return true
+}
+
+func (r *Range) GetRequestRangeHeader() (string, string) {
+
+	return HEADER_REQ_RANGE, fmt.Sprintf("items=%d-%d", r.start, r.end)
+}
+func (r *Range) GetRequestModeHeader() (string, string) {
+
+	return HEADER_COUNT_MODE, "Exact"
+}


### PR DESCRIPTION
VaultService.List will now get ALL records, not just the first page (100 records)

This is implemented by a Range Objects which uses a default of 100 records per page.

```
searchRange := model.NewRange()
for ok := true; ok; ok = searchRange.NextPage() {
		response, err := s.sling.New().****.Add(searchRange.GetRequestRangeHeader()).Add(searchRange.GetRequestModeHeader()).Receive(results, errorReport)
		searchRange.ParseResponse(response)
}
```

- **searchRange.NextPage()** Will check if there are more pages (Based on current end and total)
- **searchRange.ParseResponse(response)** Will parse the response header 'Content-Range' and update the current range and total.

The Request headers can be set by using these in the sling add function:
- **searchRange.GetRequestRangeHeader()** Gives the "Range: items 0-99" header values
- **searchRange.GetRequestModeHeader()** Gives the "topicus-Range-Count: Exact" header values