### PR TITLE
feat(KeyhubApiError): Wrapped errorreport in a error class

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -49,7 +49,7 @@ func (s *AccountService) List() (accounts []model.Account, err error) {
 		searchRange.ParseResponse(response)
 
 		if errorReport.Code > 0 {
-			err = fmt.Errorf("Could not fetch accounts, error: %s", errorReport.Message)
+			err = errorReport.Wrap("Could not fetch accounts,")
 		}
 		if err == nil {
 			if len(results.Items) > 0 {
@@ -69,7 +69,7 @@ func (s *AccountService) GetByUUID(uuid uuid.UUID) (result *model.Account, err e
 
 	_, err = s.sling.New().Get("").QueryStruct(params).Receive(al, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get Account %q. Error: %s", uuid, errorReport.Message)
+		err = errorReport.Wrap("Could not get Account %q.", uuid)
 	}
 	if err == nil {
 		if len(al.Items) > 0 {
@@ -89,7 +89,7 @@ func (s *AccountService) GetById(id int64) (result *model.Account, err error) {
 
 	_, err = s.sling.New().Get(idString).Receive(al, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get Account %q. Error: %s", idString, errorReport.Message)
+		err = errorReport.Wrap("Could not get Account %q.", idString)
 		return
 	}
 	if err == nil && al == nil {

--- a/clientapplications.go
+++ b/clientapplications.go
@@ -45,7 +45,7 @@ func (s *ClientApplicationService) Create(client *model.ClientApplication) (resu
 
 	_, err = s.sling.New().Post("").BodyJSON(clients).Receive(results, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not create ClientApplication. Error: %s", errorReport.Message)
+		err = errorReport.Wrap("Could not create ClientApplication.")
 	}
 	if err == nil {
 		if len(results.Items) > 0 {
@@ -72,7 +72,7 @@ func (s *ClientApplicationService) List() (clients []model.ClientApplication, er
 		searchRange.ParseResponse(response)
 
 		if errorReport.Code > 0 {
-			err = fmt.Errorf("Could not get ClientApplications. Error: %s", errorReport.Message)
+			err = errorReport.Wrap("Could not get ClientApplications.")
 		}
 		if err == nil {
 			if len(results.Items) > 0 {
@@ -94,7 +94,7 @@ func (s *ClientApplicationService) GetByUUID(uuid uuid.UUID) (result *model.Clie
 	params.Additional = []string{"secret", "audit"}
 	_, err = s.sling.New().Get("").QueryStruct(params).Receive(al, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get ClientApplication %q. Error: %s", uuid, errorReport.Message)
+		err = errorReport.Wrap("Could not get ClientApplication %q.", uuid)
 	}
 	if err == nil {
 		if len(al.Items) > 0 {
@@ -115,7 +115,7 @@ func (s *ClientApplicationService) GetById(id int64) (result *model.ClientApplic
 
 	_, err = s.sling.New().Get(idString).Receive(al, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get ClientApplication %q. Error: %s", idString, errorReport.Message)
+		err = errorReport.Wrap("Could not get ClientApplication %q.", idString)
 		return
 	}
 	if err == nil && al == nil {

--- a/groups.go
+++ b/groups.go
@@ -43,7 +43,7 @@ func (s *GroupService) Create(group *model.Group) (result *model.Group, err erro
 
 	_, err = s.sling.New().Post("").BodyJSON(groups).Receive(results, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not create Group. Error: %s", errorReport.Message)
+		err = errorReport.Wrap("Could not create Group.")
 	}
 	if err == nil {
 		if len(results.Items) > 0 {
@@ -65,7 +65,7 @@ func (s *GroupService) CreateMembership(group *model.Group, list *model.GroupAcc
 	_, err = s.sling.New().Post(idString+"/account").BodyJSON(list).Receive(results, errorReport)
 
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not create memberschip. Error: %s", errorReport.Message)
+		err = errorReport.Wrap("Could not create memberschip.")
 	}
 	if err == nil {
 		if len(results.Items) == 0 {
@@ -90,7 +90,7 @@ func (s *GroupService) List() (groups []model.Group, err error) {
 		searchRange.ParseResponse(response)
 
 		if errorReport.Code > 0 {
-			err = fmt.Errorf("Could not get Groups. Error: %s", errorReport.Message)
+			err = errorReport.Wrap("Could not get Groups.")
 		}
 		if err == nil {
 			if len(results.Items) > 0 {
@@ -115,7 +115,7 @@ func (s *GroupService) GetByUUID(uuid uuid.UUID) (result *model.Group, err error
 	_, err = s.sling.New().Get("").QueryStruct(params).Receive(results, errorReport)
 
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get Group %q. Error: %s", uuid.String(), errorReport.Message)
+		err = errorReport.Wrap("Could not get Group %q.", uuid.String())
 	}
 	if err == nil {
 		if len(results.Items) > 0 {
@@ -139,7 +139,7 @@ func (s *GroupService) GetById(id int64) (result *model.Group, err error) {
 
 	_, err = s.sling.New().Get(idString).QueryStruct(params).Receive(al, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get Group %q. Error: %s", idString, errorReport.Message)
+		err = errorReport.Wrap("Could not get Group %q.", idString)
 		return
 	}
 	if err == nil && al == nil {

--- a/model/error.go
+++ b/model/error.go
@@ -1,0 +1,44 @@
+package model
+
+import "fmt"
+
+// ErrorReport error report returned by KeyHub Api
+type ErrorReport struct {
+	Code             int      `json:"code"`
+	Reason           string   `json:"reason"`
+	Exception        string   `json:"exception,omitempty"`
+	Message          string   `json:"message"`
+	ApplicationError string   `json:"applicationError,omitempty"`
+	StackTrace       []string `json:"stacktrace,omitempty"`
+}
+
+func (er ErrorReport) Error() string {
+	return er.Message
+}
+
+// Wrap  rap the errorReport within an error of type KeyhubApiError
+func (er ErrorReport) Wrap(format string, any ...any) error {
+	return &KeyhubApiError{
+		Message: fmt.Sprintf(format, any...),
+		Report:  ErrorReport{},
+	}
+}
+
+// NewKeyhubApiError Create new KeyhubApiError from ErrorReport
+func NewKeyhubApiError(errorReport ErrorReport, format string, any ...any) *KeyhubApiError {
+
+	err := KeyhubApiError{
+		Message: fmt.Sprintf(format, any...),
+		Report:  errorReport,
+	}
+	return &err
+}
+
+type KeyhubApiError struct {
+	Message string
+	Report  ErrorReport
+}
+
+func (e KeyhubApiError) Error() string {
+	return fmt.Sprintf("%s Error: %s", e.Message, e.Report.Message)
+}

--- a/model/error.go
+++ b/model/error.go
@@ -42,3 +42,7 @@ type KeyhubApiError struct {
 func (e KeyhubApiError) Error() string {
 	return fmt.Sprintf("%s Error: %s", e.Message, e.Report.Message)
 }
+
+func (e KeyhubApiError) Unwrap() error {
+	return e.Report
+}

--- a/model/linkable.go
+++ b/model/linkable.go
@@ -34,15 +34,6 @@ func (l *Linkable) Self() *Link {
 	return nil
 }
 
-type ErrorReport struct {
-	Code             int      `json:"code"`
-	Reason           string   `json:"reason"`
-	Exception        string   `json:"exception,omitempty"`
-	Message          string   `json:"message"`
-	ApplicationError string   `json:"applicationError,omitempty"`
-	StackTrace       []string `json:"stacktrace,omitempty"`
-}
-
 type Link struct {
 	ID   int64  `json:"id"`
 	Rel  string `json:"rel"`

--- a/systems.go
+++ b/systems.go
@@ -61,7 +61,7 @@ func (s *SystemService) FindGroupOnSystem(system *model.ProvisionedSystem, query
 		searchRange.ParseResponse(response)
 
 		if errorReport.Code > 0 {
-			err = fmt.Errorf("could not get GroupsOnSystem for System %s. Error: %s", system.UUID, errorReport.Message)
+			err = errorReport.Wrap("could not get GroupsOnSystem for System %s.", system.UUID)
 			return nil, err
 		}
 
@@ -85,7 +85,7 @@ func (s *SystemService) CreateGroupOnSystem(groupOnSystem *model.GroupOnSystem) 
 
 	_, err = s.sling.New().Post(groupId+"/group").BodyJSON(list).Receive(results, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not create GroupOnSystem. Error: %s", errorReport.Message)
+		err = errorReport.Wrap("Could not create GroupOnSystem.")
 	}
 	if err == nil {
 		if len(results.Items) > 0 {
@@ -113,7 +113,7 @@ func (s *SystemService) GetGroupOnSystem(system *model.ProvisionedSystem, groupI
 	}
 	_, err = s.sling.New().Get(idString+"/group/"+groupIdString).QueryStruct(params).Receive(al, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get GroupOnSystem \"%s/%s\". Error: %s", idString, groupIdString, errorReport.Message)
+		err = errorReport.Wrap("Could not get GroupOnSystem \"%s/%s\".", idString, groupIdString)
 		return
 	}
 	if err == nil && al == nil {
@@ -143,7 +143,7 @@ func (s *SystemService) DeleteGroupOnSystem(groupOnSystem *model.GroupOnSystem) 
 
 	_, err = s.sling.New().Delete(groupId+"/group/"+gosId).QueryStruct(params).Receive(result, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("could not delete GroupOnSystem. Error: %s", errorReport.Message)
+		err = errorReport.Wrap("could not delete GroupOnSystem.")
 	}
 	return
 }
@@ -170,7 +170,7 @@ func (s *SystemService) GetByUUID(uuid uuid.UUID) (system *model.ProvisionedSyst
 	_, err = s.sling.New().Get("").QueryStruct(params).Receive(results, errorReport)
 
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get System %q. Error: %s", uuid.String(), errorReport.Message)
+		err = errorReport.Wrap("Could not get System %q.", uuid.String())
 	}
 	if err == nil {
 		if len(results.Items) > 0 {
@@ -194,7 +194,7 @@ func (s *SystemService) GetById(id int64) (system *model.ProvisionedSystem, err 
 	}
 	_, err = s.sling.New().Get(idString).QueryStruct(params).Receive(al, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get Group %q. Error: %s", idString, errorReport.Message)
+		err = errorReport.Wrap("Could not get Group %q.", idString)
 		return
 	}
 	if err == nil && al == nil {

--- a/vaults.go
+++ b/vaults.go
@@ -49,7 +49,7 @@ func (s *VaultService) Create(group *model.Group, vaultRecord *model.VaultRecord
 
 	_, err = s.sling.New().Path(selfUrl.Path+"/vault/").Post("record").QueryStruct(params).BodyJSON(vaultRecords).Receive(results, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not create VaultRecord in Group %q. Error: %s", group.UUID, errorReport.Message)
+		err = errorReport.Wrap("Could not create VaultRecord in Group %q.", group.UUID)
 	}
 	if err == nil {
 		if len(results.Items) > 0 {
@@ -91,7 +91,7 @@ func (s *VaultService) List(group *model.Group, query *model.VaultRecordQueryPar
 		searchRange.ParseResponse(response)
 
 		if errorReport.Code > 0 {
-			err = fmt.Errorf("Could not get VaultRecords of Group %q. Error: %s", group.UUID, errorReport.Message)
+			err = errorReport.Wrap("Could not get VaultRecords of Group %q.", group.UUID)
 		}
 		if err == nil {
 			if len(results.Items) > 0 {
@@ -112,7 +112,7 @@ func (s *VaultService) getMyClientId() (id int64, err error) {
 
 	_, err = s.sling.New().Get("/keyhub/rest/v1/client/me").Receive(&me, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("could not determine client details, errorReport: %s", errorReport.Message)
+		err = errorReport.Wrap("could not determine client details")
 		return
 	}
 	if err != nil {
@@ -164,7 +164,7 @@ func (s *VaultService) findForClient(query model.VaultRecordSearchQueryParams, a
 	_, err = s.sling.New().Get("/keyhub/rest/v1/vaultrecord/").QueryStruct(query).Receive(results, errorReport)
 
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not find VaultRecord. Error: %s", errorReport.Message)
+		err = errorReport.Wrap("Could not find VaultRecord.")
 	}
 	if err == nil {
 		if len(results.Items) > 0 {
@@ -224,7 +224,7 @@ func (s *VaultService) GetByUUID(group *model.Group, uuid uuid.UUID, additional 
 
 	_, err = s.sling.New().Path(selfUrl.Path+"/vault/").Get("record").QueryStruct(query).Receive(results, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get VaultRecord %q of Group %q. Error: %s", uuid.String(), group.UUID, errorReport.Message)
+		err = errorReport.Wrap("Could not get VaultRecord %q of Group %q.", uuid.String(), group.UUID)
 	}
 	if err == nil {
 		if len(results.Items) > 0 {
@@ -253,7 +253,7 @@ func (s *VaultService) GetByID(group *model.Group, id int64, additional *model.V
 
 	_, err = s.sling.New().Path(selfUrl.Path+"/vault/record/").Get(idString).QueryStruct(query).Receive(al, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get VaultRecord %q of Group %q. Error: %s", idString, group.UUID, errorReport.Message)
+		err = errorReport.Wrap("Could not get VaultRecord %q of Group %q.", idString, group.UUID)
 		return
 	}
 	if err == nil && al == nil {
@@ -286,7 +286,7 @@ func (s *VaultService) Update(group *model.Group, vaultRecord *model.VaultRecord
 
 	_, err = s.sling.New().Path(selfUrl.Path).Put("").BodyJSON(vaultRecord).QueryStruct(query).Receive(al, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not update VaultRecord %q of Group %q. Error: %s", vaultRecord.UUID, group.UUID, errorReport.Message)
+		err = errorReport.Wrap("Could not update VaultRecord %q of Group %q.", vaultRecord.UUID, group.UUID)
 		return
 	}
 
@@ -308,7 +308,7 @@ func (s *VaultService) DeleteByUUID(group *model.Group, uuid uuid.UUID) (err err
 
 	_, err = s.sling.New().Path(selfUrl.Path).Delete("").Receive(nil, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not delete VaultRecord %q of Group %q. Error: %s", uuid.String(), group.UUID, errorReport.Message)
+		err = errorReport.Wrap("Could not delete VaultRecord %q of Group %q.", uuid.String(), group.UUID)
 	}
 
 	return
@@ -322,7 +322,7 @@ func (s *VaultService) DeleteByID(group *model.Group, id int64) (err error) {
 
 	_, err = s.sling.New().Path(selfUrl.Path+"/vault/record/").Delete(idString).Receive(nil, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not delete VaultRecord %q of Group %q. Error: %s", idString, group.UUID, errorReport.Message)
+		err = errorReport.Wrap("Could not delete VaultRecord %q of Group %q.", idString, group.UUID)
 	}
 
 	return

--- a/version.go
+++ b/version.go
@@ -42,8 +42,7 @@ func (s *VersionService) Get() (v *model.VersionInfo, err error) {
 		return
 	}
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get acceptable contract versions. Error: %s", errorReport.Message)
-		return
+		return nil, errorReport.Wrap("Could not fetch acceptable contract versions")
 	}
 	if resp.StatusCode >= 300 {
 		err = fmt.Errorf("Could not fetch acceptable contract versions. Error: %s", resp.Status)


### PR DESCRIPTION
With this PR all Service functions can return a KeyhubApiError object implementing the error interface.

In normal error usage , it still returns the default error message, but when cast it allows access to more detailed info

usage:

```go

#errors.As way
var apiError model.KeyhubApiError
if errors.As(err, &apiError) {
	fmt.Println("Server message:", apiError.Report.Message)
	fmt.Println("Server stack traces:", strings.Join(apiError.Report.StackTrace, "\n"))
} else {
	fmt.Println("Error", err.Error())
}


# Detect self
if err != nil {
	if apiError, ok := err.(*model.KeyhubApiError); ok {
		fmt.Println("Server message:", apiError.Report.Message)
		fmt.Println("Server stack traces:", strings.Join(apiError.Report.StackTrace, "\n"))
	} else {
		fmt.Println("Error", err.Error())
	}
	os.Exit(1)
}
```
