### PR TITLE
feat(VaultRecord): Add field for endDate and Warning Period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Issue #18 : Improved error reporting by returning the ErrorReport
 ### Fixed
 - Issue #20 : Fixed index-out-of-range panic while getting vaultRecord  
+- Issue #21 : Can't set expire / end date for vault records
 
 ## [1.2.3] - 2022-11-07
 ### Fixed

--- a/model/vaultrecord.go
+++ b/model/vaultrecord.go
@@ -16,6 +16,7 @@
 package model
 
 import (
+	"encoding/json"
 	"net/url"
 	"time"
 )
@@ -24,17 +25,68 @@ type VaultRecordList struct {
 	Items []VaultRecord `json:"items"`
 }
 
+const (
+	WARNINGPERIOD_AT_EXPIRATION RecordWarningPeriod = "AT_EXPIRATION"
+	WARNINGPERIOD_TWO_WEEKS     RecordWarningPeriod = "TWO_WEEKS"
+	WARNINGPERIOD_ONE_MONTH     RecordWarningPeriod = "ONE_MONTH"
+	WARNINGPERIOD_TWO_MONTHS    RecordWarningPeriod = "TWO_MONTHS"
+	WARNINGPERIOD_THREE_MONTHS  RecordWarningPeriod = "THREE_MONTHS"
+	WARNINGPERIOD_SIX_MONTHS    RecordWarningPeriod = "SIX_MONTHS"
+	WARNINGPERIOD_NEVER         RecordWarningPeriod = "NEVER"
+)
+
+type RecordWarningPeriod string
+
 type VaultRecord struct {
 	Linkable
 	AdditionalObjects *VaultRecordAdditionalObjects `json:"additionalObjects,omitempty"`
 
-	UUID     string   `json:"uuid,omitempty"`
-	Name     string   `json:"name"`
-	URL      string   `json:"url,omitempty"`
-	Username string   `json:"username,omitempty"`
-	Color    string   `json:"color,omitempty"` // see bottom of file for color values
-	Filename string   `json:"filename,omitempty"`
-	Types    []string `json:"types,omitempty"`
+	UUID          string              `json:"uuid,omitempty"`
+	Name          string              `json:"name"`
+	URL           string              `json:"url,omitempty"`
+	Username      string              `json:"username,omitempty"`
+	Color         string              `json:"color,omitempty"` // see bottom of file for color values
+	Filename      string              `json:"filename,omitempty"`
+	Types         []string            `json:"types,omitempty"`
+	EndDate       time.Time           `json:"endDate,omitempty" layout:"2006-01-02"` // Layout don't work for json, only url but kept as reference
+	WarningPeriod RecordWarningPeriod `json:"warningPeriod,omitempty"`
+}
+
+// Custom marshal function to format time.Time enddate to "Y-m-d" string
+func (vr *VaultRecord) MarshalJSON() ([]byte, error) {
+
+	type Alias VaultRecord
+	aux := &struct {
+		EndDate string `json:"endDate,omitempty"`
+		*Alias
+	}{
+		EndDate: vr.EndDate.Format("2006-02-01"),
+		Alias:   (*Alias)(vr),
+	}
+
+	return json.Marshal(aux)
+}
+
+// Custom unmarshal function to parse "Y-m-d" enddate to a time.Time field
+func (vr *VaultRecord) UnmarshalJSON(data []byte) error {
+
+	type Alias VaultRecord
+	var err error
+	aux := &struct {
+		EndDate string `json:"endDate"`
+		*Alias
+	}{
+		Alias: (*Alias)(vr),
+	}
+	if err = json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	vr.EndDate, err = time.Parse("2006-02-01", aux.EndDate)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 type VaultRecordAdditionalObjects struct {


### PR DESCRIPTION
This PR closes issue #21 by adding the two fields. 

```golang
password := "Blaat"
record := model.NewVaultRecord("Test", &model.VaultRecordSecretAdditionalObject{Password: &password})
record.EndDate = time.Now().AddDate(1, 0, 0) // years, months, days
record.WarningPeriod = model.WARNINGPERIOD_TWO_MONTHS
```

