### PR TITLE
Feature/17 implement service accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Issue #17 : Implement Service Accounts
+
 ## [1.2.4] - 2023-02-23
 ### Changed
 - Issue #18 : Improved error reporting by returning the ErrorReport

--- a/keyhub.go
+++ b/keyhub.go
@@ -45,6 +45,7 @@ type Client struct {
 	Systems            *SystemService
 	ClientApplications *ClientApplicationService
 	Vaults             *VaultService
+	ServiceAccounts    *ServiceAccountService
 }
 
 func NewClientDefault(issuer string, clientID string, clientSecret string) (*Client, error) {
@@ -121,5 +122,6 @@ func NewClient(httpClient *http.Client, issuer string, clientID string, clientSe
 		Groups:             newGroupService(oauth2Sling.New()),
 		Systems:            newSystemService(oauth2Sling.New()),
 		Vaults:             newVaultService(versionedSling.New().Client(vaultClient)),
+		ServiceAccounts:    NewServiceAccountService(oauth2Sling),
 	}, nil
 }

--- a/keyhub_test.go
+++ b/keyhub_test.go
@@ -16,9 +16,11 @@
 package keyhub
 
 import (
+	"github.com/google/go-querystring/query"
 	"net/http"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jarcoal/httpmock"
@@ -131,4 +133,58 @@ func TestGroups(t *testing.T) {
 	if group.Self().ID != 1 {
 		t.Fatalf("ERROR group with id 1 not found")
 	}
+}
+
+func verifyQueryParams(t *testing.T, queryParams interface{}, expected string) {
+
+	r, err := query.Values(queryParams)
+	if err != nil {
+		t.Fatalf("Could not parse query params")
+	}
+
+	result := r.Encode()
+
+	if result != expected {
+		t.Fatalf("Parse error, result `%s` did not match expected `%s`", result, expected)
+	}
+
+}
+
+func TestQueries(t *testing.T) {
+
+	var q model.ServiceAccountQueryParams
+
+	q = model.ServiceAccountQueryParams{}
+	verifyQueryParams(t, q, "")
+
+	CreatedAfter, _ := time.Parse("2006-01-02", "2023-01-04")
+	CreatedBefore, _ := time.Parse("2006-01-02", "2023-01-04")
+	ModifiedSince, _ := time.Parse("2006-01-02", "2023-01-04")
+
+	q = model.ServiceAccountQueryParams{
+		UUID:                         "51f0cb1d-5745-4512-8d0d-bb28e2449d3f",
+		CreatedAfter:                 CreatedAfter,
+		CreatedBefore:                CreatedBefore,
+		ModifiedSince:                ModifiedSince,
+		Additional:                   nil,
+		Exclude:                      []int64{1000},
+		Id:                           []int64{1001},
+		CQLQuery:                     "Blaat",
+		Active:                       "BOTH",
+		GroupOnSystem:                1002,
+		GroupOnSystemOwners:          1003,
+		Name:                         "Name",
+		NameContains:                 "Contains",
+		NameDoesNotStartWith:         "NotStartWith",
+		NameStartsWith:               "StartsWith",
+		Password:                     1004,
+		PasswordRotation:             "MANUAL",
+		RequestedGroupOnSystemOwners: 1005,
+		System:                       1006,
+		TechnicalAdministrator:       1007,
+		Username:                     "Username",
+	}
+
+	verifyQueryParams(t, q, "Username=Username&active=BOTH&createdAfter=2023-01-04T00%3A00%3A00Z&createdBefore=2023-01-04T00%3A00%3A00Z&createdBefore=2023-01-04T00%3A00%3A00Z&exclude=1000&groupOnSystem=1002&groupOnSystemOwners=1003&id=1001&name=Name&nameContains=Contains&nameDoesNotStartWith=NotStartWith&nameStartsWith=StartsWith&password=1004&passwordRotation=MANUAL&q=Blaat&requestedGroupOnSystemOwners=1005&system=1006&technicalAdministrator=1007&uuid=51f0cb1d-5745-4512-8d0d-bb28e2449d3f")
+
 }

--- a/model/serviceaccount.go
+++ b/model/serviceaccount.go
@@ -62,13 +62,27 @@ type ServiceAccountGroup struct {
 }
 
 type ServiceAccountQueryParams struct {
-	UUID          string                               `url:"uuid,omitempty"`
-	CreatedAfter  time.Time                            `url:"createdAfter,omitempty" layout:"2006-01-02T15:04:05Z"`
-	CreatedBefore time.Time                            `url:"createdBefore,omitempty" layout:"2006-01-02T15:04:05Z"`
-	ModifiedSince time.Time                            `url:"createdBefore,omitempty" layout:"2006-01-02T15:04:05Z"`
-	Additional    *ServiceAccountAdditionalQueryParams `url:"additional,omitempty"`
-	Exclude       []int64                              `url:"exclude,omitempty"`
-	id            []int64                              `url:"id,omitempty"`
+	UUID                         string                               `url:"uuid,omitempty"`
+	CreatedAfter                 time.Time                            `url:"createdAfter,omitempty" layout:"2006-01-02T15:04:05Z"`
+	CreatedBefore                time.Time                            `url:"createdBefore,omitempty" layout:"2006-01-02T15:04:05Z"`
+	ModifiedSince                time.Time                            `url:"createdBefore,omitempty" layout:"2006-01-02T15:04:05Z"`
+	Additional                   *ServiceAccountAdditionalQueryParams `url:"additional,omitempty"`
+	Exclude                      []int64                              `url:"exclude,omitempty"`
+	Id                           []int64                              `url:"id,omitempty"`
+	CQLQuery                     string                               `url:"q,omitempty"`
+	Active                       string                               `url:"active,omitempty"`
+	GroupOnSystem                int64                                `url:"groupOnSystem,omitempty"`
+	GroupOnSystemOwners          int64                                `url:"groupOnSystemOwners,omitempty"`
+	Name                         string                               `url:"name,omitempty"`
+	NameContains                 string                               `url:"nameContains,omitempty"`
+	NameDoesNotStartWith         string                               `url:"nameDoesNotStartWith,omitempty"`
+	NameStartsWith               string                               `url:"nameStartsWith,omitempty"`
+	Password                     int64                                `url:"password,omitempty"`
+	PasswordRotation             string                               `url:"passwordRotation,omitempty"`
+	RequestedGroupOnSystemOwners int64                                `url:"requestedGroupOnSystemOwners,omitempty"`
+	System                       int64                                `url:"system,omitempty"`
+	TechnicalAdministrator       int64                                `url:"technicalAdministrator,omitempty"`
+	Username                     string                               `url:"Username,omitempty"`
 }
 
 type ServiceAccountAdditionalQueryParams struct {

--- a/model/serviceaccount.go
+++ b/model/serviceaccount.go
@@ -1,6 +1,10 @@
 package model
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+	"net/url"
+	"time"
+)
 
 const (
 	SA_PASSWORD_ROTATION_MANUAL     SAPasswordRotation = "MANUAL"
@@ -55,6 +59,27 @@ type ServiceAccountGroupList struct {
 
 type ServiceAccountGroup struct {
 	GroupOnSystem
+}
+
+type ServiceAccountQueryParams struct {
+	UUID          string                               `url:"uuid,omitempty"`
+	CreatedAfter  time.Time                            `url:"createdAfter,omitempty" layout:"2006-01-02T15:04:05Z"`
+	CreatedBefore time.Time                            `url:"createdBefore,omitempty" layout:"2006-01-02T15:04:05Z"`
+	ModifiedSince time.Time                            `url:"createdBefore,omitempty" layout:"2006-01-02T15:04:05Z"`
+	Additional    *ServiceAccountAdditionalQueryParams `url:"additional,omitempty"`
+	Exclude       []int64                              `url:"exclude,omitempty"`
+	id            []int64                              `url:"id,omitempty"`
+}
+
+type ServiceAccountAdditionalQueryParams struct {
+	Audit   bool `url:"audit"`
+	Groups  bool `url:"groups"`
+	Secrets bool `url:"secrets"`
+}
+
+// EncodeValues Custom url encoder to convert bools to list
+func (p ServiceAccountAdditionalQueryParams) EncodeValues(key string, v *url.Values) error {
+	return additionalQueryParamsUrlEncoder(p, key, v)
 }
 
 func NewServiceAccount() *ServiceAccount {

--- a/model/serviceaccount.go
+++ b/model/serviceaccount.go
@@ -1,0 +1,68 @@
+package model
+
+import "github.com/google/uuid"
+
+const (
+	SA_PASSWORD_ROTATION_MANUAL     SAPasswordRotation = "MANUAL"
+	SA_PASSWORD_ROTATION_MANUAL_SIV SAPasswordRotation = "MANUAL_STORED_IN_VAULT"
+	SA_PASSWORD_ROTATION_DAILY      SAPasswordRotation = "DAILY"
+)
+
+type SAPasswordRotation string
+
+type ServiceAccountList struct {
+	Items []ServiceAccount `json:"items"`
+}
+
+type ServiceAccountPrimer struct {
+	//#/components/schemas/serviceaccount_ServiceAccountPrimer
+	//serviceaccount_ServiceAccount
+
+	Linkable
+
+	Active   bool               `json:"active"`
+	UUID     uuid.UUID          `json:"uuid,omitempty"`
+	Name     string             `json:"name"`
+	Username string             `json:"username"`
+	System   *ProvisionedSystem `json:"system"`
+}
+
+type ServiceAccount struct {
+	ServiceAccountPrimer
+
+	TechnicalAdministrator *Group             `json:"technicalAdministrator,omitempty"`
+	PasswordRotation       SAPasswordRotation `json:"passwordRotation"`
+	Description            string             `json:"description,omitempty"`
+	Password               *VaultRecord       `json:"password,omitempty"`
+}
+
+// AsPrimer Return ServiceAccount with only Primer data
+func (s *ServiceAccount) AsPrimer() *ServiceAccount {
+	serviceAccount := &ServiceAccount{}
+	serviceAccount.ServiceAccountPrimer = s.ServiceAccountPrimer
+	return serviceAccount
+}
+
+// ToPrimer Convert to serviceAccountPrimer
+func (s *ServiceAccount) ToPrimer() *ServiceAccountPrimer {
+	serviceAccountPrimer := s.ServiceAccountPrimer
+	return &serviceAccountPrimer
+}
+
+type ServiceAccountGroupList struct {
+	Items []ServiceAccountGroup `json:"items"`
+}
+
+type ServiceAccountGroup struct {
+	GroupOnSystem
+}
+
+func NewServiceAccount() *ServiceAccount {
+
+	return &ServiceAccount{
+		ServiceAccountPrimer: ServiceAccountPrimer{
+			Linkable: Linkable{DType: "serviceaccount.ServiceAccount"},
+		},
+		PasswordRotation: SA_PASSWORD_ROTATION_MANUAL,
+	}
+}

--- a/serviceaccounts.go
+++ b/serviceaccounts.go
@@ -41,7 +41,7 @@ func (s *ServiceAccountService) GetByUUID(uuid uuid.UUID) (result *model.Service
 	list := new(model.ServiceAccountList)
 	errorReport := new(model.ErrorReport)
 
-	params := &model.AccountQueryParams{UUID: uuid.String()}
+	params := &model.ServiceAccountQueryParams{UUID: uuid.String()}
 
 	_, err = s.sling.New().Get("").QueryStruct(params).Receive(list, errorReport)
 	if errorReport.Code > 0 {
@@ -79,9 +79,19 @@ func (s *ServiceAccountService) GetById(id int64) (result *model.ServiceAccount,
 	return
 }
 
+//// List Retrieve all vault records for a group (secrets are not included, default audit = true)
+//func (s *VaultService) List(group *model.Group, query *model.VaultRecordQueryParams, additional *model.VaultRecordAdditionalQueryParams) (records []model.VaultRecord, err error) {
+
 // List all Service Accounts
-func (s *ServiceAccountService) List() (list []model.ServiceAccount, err error) {
+func (s *ServiceAccountService) List(query *model.ServiceAccountQueryParams, additional *model.ServiceAccountAdditionalQueryParams) (list []model.ServiceAccount, err error) {
 	list = []model.ServiceAccount{}
+
+	if query == nil {
+		query = new(model.ServiceAccountQueryParams)
+	}
+	if additional != nil {
+		query.Additional = additional
+	}
 
 	searchRange := model.NewRange()
 
@@ -91,7 +101,7 @@ func (s *ServiceAccountService) List() (list []model.ServiceAccount, err error) 
 
 		errorReport := new(model.ErrorReport)
 		results := new(model.ServiceAccountList)
-		response, err = s.sling.New().Get("").Add(searchRange.GetRequestRangeHeader()).Add(searchRange.GetRequestModeHeader()).Receive(results, errorReport)
+		response, err = s.sling.New().Get("").QueryStruct(query).Add(searchRange.GetRequestRangeHeader()).Add(searchRange.GetRequestModeHeader()).Receive(results, errorReport)
 		searchRange.ParseResponse(response)
 
 		if errorReport.Code > 0 {

--- a/serviceaccounts.go
+++ b/serviceaccounts.go
@@ -1,0 +1,87 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package keyhub
+
+import (
+	"fmt"
+	"github.com/dghubble/sling"
+	"github.com/topicuskeyhub/go-keyhub/model"
+	"net/http"
+)
+
+type ServiceAccountService struct {
+	sling *sling.Sling
+}
+
+func NewServiceAccountService(sling *sling.Sling) *ServiceAccountService {
+	return &ServiceAccountService{
+		sling: sling.Path("/keyhub/rest/v1/serviceaccount/"),
+	}
+}
+
+func (s *ServiceAccountService) List() (list []model.ServiceAccount, err error) {
+	list = []model.ServiceAccount{}
+
+	searchRange := model.NewRange()
+
+	var response *http.Response
+
+	for ok := true; ok; ok = searchRange.NextPage() {
+
+		errorReport := new(model.ErrorReport)
+		results := new(model.ServiceAccountList)
+		response, err = s.sling.New().Get("").Add(searchRange.GetRequestRangeHeader()).Add(searchRange.GetRequestModeHeader()).Receive(results, errorReport)
+		searchRange.ParseResponse(response)
+
+		if errorReport.Code > 0 {
+			err = errorReport.Wrap("Could not get Groups.")
+		}
+		if err == nil {
+			if len(results.Items) > 0 {
+				list = append(list, results.Items...)
+			}
+		}
+
+	}
+
+	return
+}
+
+func (s *ServiceAccountService) Create(serviceaccount *model.ServiceAccount) (result *model.ServiceAccount, err error) {
+	serviceAccounts := new(model.ServiceAccountList)
+	results := new(model.ServiceAccountList)
+	errorReport := new(model.ErrorReport)
+	serviceAccounts.Items = append(serviceAccounts.Items, *serviceaccount)
+
+	_, err = s.sling.New().Post("").BodyJSON(serviceAccounts).Receive(results, errorReport)
+
+	if errorReport.Code > 0 {
+		fmt.Println("Wrap", errorReport.Message)
+		//apiErr := model.NewKeyhubApiError(*errorReport, "Could not create ServiceAccount in System %q.", serviceaccount.System.Name)
+		err = errorReport.Wrap("Could not create ServiceAccount in System %q.", serviceaccount.System.Name)
+
+		return
+	}
+	if err == nil {
+		if len(results.Items) > 0 {
+			result = &results.Items[0]
+		} else {
+			err = fmt.Errorf("Could not create ServiceAccount")
+		}
+	}
+
+	return
+}

--- a/serviceaccounts.go
+++ b/serviceaccounts.go
@@ -18,20 +18,68 @@ package keyhub
 import (
 	"fmt"
 	"github.com/dghubble/sling"
+	"github.com/google/uuid"
 	"github.com/topicuskeyhub/go-keyhub/model"
 	"net/http"
+	"net/url"
+	"strconv"
 )
 
 type ServiceAccountService struct {
 	sling *sling.Sling
 }
 
+// NewServiceAccountService Create new ServiceAccountService
 func NewServiceAccountService(sling *sling.Sling) *ServiceAccountService {
 	return &ServiceAccountService{
 		sling: sling.Path("/keyhub/rest/v1/serviceaccount/"),
 	}
 }
 
+// GetByUUID Get Service account by UUID
+func (s *ServiceAccountService) GetByUUID(uuid uuid.UUID) (result *model.ServiceAccount, err error) {
+	list := new(model.ServiceAccountList)
+	errorReport := new(model.ErrorReport)
+
+	params := &model.AccountQueryParams{UUID: uuid.String()}
+
+	_, err = s.sling.New().Get("").QueryStruct(params).Receive(list, errorReport)
+	if errorReport.Code > 0 {
+		err = errorReport.Wrap("Could not get ServiceAccount %q.", uuid)
+	}
+	if err == nil {
+		if len(list.Items) > 0 {
+			result = &list.Items[0]
+		} else {
+			err = fmt.Errorf("Account %q not found", uuid.String())
+		}
+	}
+
+	return
+}
+
+// GetById Get Service account by ID
+func (s *ServiceAccountService) GetById(id int64) (result *model.ServiceAccount, err error) {
+	sa := new(model.ServiceAccount)
+	errorReport := new(model.ErrorReport)
+	idString := strconv.FormatInt(id, 10)
+
+	_, err = s.sling.New().Get(idString).Receive(sa, errorReport)
+	if errorReport.Code > 0 {
+		err = errorReport.Wrap("Could not get ServiceAccount %q.", idString)
+		return
+	}
+	if err == nil && sa == nil {
+		err = fmt.Errorf("Account %q not found", idString)
+		return
+	}
+
+	//use an intermediate variable so sling can fill that variable with the json results. When request was succesful we use the variable as return value.
+	result = sa
+	return
+}
+
+// List all Service Accounts
 func (s *ServiceAccountService) List() (list []model.ServiceAccount, err error) {
 	list = []model.ServiceAccount{}
 
@@ -60,6 +108,7 @@ func (s *ServiceAccountService) List() (list []model.ServiceAccount, err error) 
 	return
 }
 
+// Create  Create a serviceaccount
 func (s *ServiceAccountService) Create(serviceaccount *model.ServiceAccount) (result *model.ServiceAccount, err error) {
 	serviceAccounts := new(model.ServiceAccountList)
 	results := new(model.ServiceAccountList)
@@ -84,4 +133,53 @@ func (s *ServiceAccountService) Create(serviceaccount *model.ServiceAccount) (re
 	}
 
 	return
+}
+
+// Update  Update service account
+func (s *ServiceAccountService) Update(serviceAccount *model.ServiceAccount) (result *model.ServiceAccount, err error) {
+	updated := new(model.ServiceAccount)
+	errorReport := new(model.ErrorReport)
+
+	selfUrl, _ := url.Parse(serviceAccount.Self().Href)
+
+	_, err = s.sling.New().Path(selfUrl.Path).Put("").BodyJSON(serviceAccount).Receive(updated, errorReport)
+	if errorReport.Code > 0 {
+		err = errorReport.Wrap("Could not update ServiceAccount %s", serviceAccount.UUID)
+		return
+	}
+	result = updated
+	return
+}
+
+// Delete Delete a service account by object
+func (s *ServiceAccountService) Delete(serviceAccount *model.ServiceAccount) (err error) {
+	errorReport := new(model.ErrorReport)
+
+	selfUrl, _ := url.Parse(serviceAccount.Self().Href)
+
+	_, err = s.sling.New().Path(selfUrl.Path).Delete("").Receive(nil, errorReport)
+	if errorReport.Code > 0 {
+		err = errorReport.Wrap("Could not delete ServiceAccount %q", serviceAccount.UUID)
+	}
+
+	return
+}
+
+// DeleteByUUID  Delete a service account by uuid for a certain group
+func (s *ServiceAccountService) DeleteByUUID(uuid uuid.UUID) (err error) {
+	serviceAccount, err := s.GetByUUID(uuid)
+	if err != nil {
+		return err
+	}
+
+	return s.Delete(serviceAccount)
+}
+
+// DeleteByID  Delete a service account by ID
+func (s *ServiceAccountService) DeleteByID(id int64) (err error) {
+	serviceAccount, err := s.GetById(id)
+	if err != nil {
+		return err
+	}
+	return s.Delete(serviceAccount)
 }


### PR DESCRIPTION
This PR will allow the listing and creation of Services accounts:

# List All:
```golang
res, _ := client.ServiceAccounts.List()
for _, sa := range res {
	fmt.Println("Service account: ", sa.Name, sa.System.Name, sa.System.Type)
}
```

# Create new
```golang
newSA := model.NewServiceAccount()
newSA.Name = "A Service Account"
newSA.Username = "service-account"

newSA.System = provSys
newSA.TechnicalAdministrator = group

tmp, _ := client.ServiceAccounts.Create(newSA)
```

# Update existing
```golang

existingSa, _ := client.ServiceAccounts.GetByUUID(uuid.MustParse("00000-00-000"))
existingSa.Name = "Example"
existingSa.Username = "example"

updatedSA, _ := client.ServiceAccounts.Update(existingSa)
```

# Delete
```golang
// By Object
existingSa, _ := client.ServiceAccounts.GetByUUID(uuid.MustParse("00000-00-000"))
_ := client.ServiceAccounts.Delete(existingSa)
// By UUID
_ := client.ServiceAccounts.DeleteByUUID(uuid.MustParse("00000-00-000"))
// By ID
_ := client.ServiceAccounts.DeleteByID(1337)
```