### PR TITLE
Allow creation of GroupOnSystem without provGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Issue #24 : Allow creation of GroupOnSystem without provGroups
 
 ## [1.2.4] - 2023-02-23
 ### Changed

--- a/model/provisioning.go
+++ b/model/provisioning.go
@@ -61,13 +61,14 @@ type GroupOnSystem struct {
 func NewProvisioningGroupList() *ProvisioningGroupList {
 	return &ProvisioningGroupList{
 		DType: "LinkableWrapper",
+		Items: make([]ProvisioningGroup, 0),
 	}
 }
 
 // ProvisioningGroupList List of ProvisioningGroup
 type ProvisioningGroupList struct {
 	DType string              `json:"$type,omitempty"`
-	Items []ProvisioningGroup `json:"items,omitempty"`
+	Items []ProvisioningGroup `json:"items"`
 }
 
 // NewGroupOnSystemAdditionalObject Initialize a new GroupOnSystemAdditionalObject
@@ -92,6 +93,11 @@ func (g *GroupOnSystem) AddProvGroup(group ...ProvisioningGroup) {
 		g.AdditionalObjects.ProvGroups.Items,
 		group...,
 	)
+}
+
+// NoProvGroups Set empty list for ProvisioningGroups
+func (g *GroupOnSystem) NoProvGroups() {
+	g.AdditionalObjects = NewGroupOnSystemAdditionalObject()
 }
 
 // SetType Set type of GroupOnSystem, use one of the GOS_TYPE_* constants
@@ -134,6 +140,14 @@ func (g *GroupOnSystem) SetName(name string) {
 func NewGroupOnSystem() *GroupOnSystem {
 	return &GroupOnSystem{
 		Linkable: Linkable{DType: "provisioning.GroupOnSystem"},
+	}
+}
+
+// NewGroupOnSystemWithEmptyProvGroup Initialize a new GroupOnSystem with an empty provgroup list, disabling owner as default provgroup
+func NewGroupOnSystemWithEmptyProvGroup() *GroupOnSystem {
+	return &GroupOnSystem{
+		Linkable:          Linkable{DType: "provisioning.GroupOnSystem"},
+		AdditionalObjects: NewGroupOnSystemAdditionalObject(),
 	}
 }
 


### PR DESCRIPTION
Add functions to set empty list of provision groups, and do send empty items list

To create a grouponsystem without provgroups you can use 2 options:

1. Init a GroupOnSystem object using the `NewGroupOnSystemWithEmptyProvGroup` function
```go
	gos = keyhubmodel.NewGroupOnSystemWithEmptyProvGroup()
	gos.SetType(keyhubmodel.GOS_TYPE_POSIX)
	gos.Owner = group.AsPrimer()
	gos.System = system.AsPrimer()
	gos.SetName("Name")
	_, _ = client.Systems.CreateGroupOnSystem(gos)
```

2. Use the `NoProvGroups()` function of the GroupOnSystem object
```go
	gos = keyhubmodel.NewGroupOnSystem()
	gos.SetType(keyhubmodel.GOS_TYPE_POSIX)
	gos.Owner = group.AsPrimer()
	gos.System = system.AsPrimer()
	gos.SetName("Name")
	gos.NoProvGroups()  // Create empty provgroup list disabling Owner as default provgroup
	_, _ = client.Systems.CreateGroupOnSystem(gos)
```

note: Both ways still allow you to add additional provision groups, but `NoProvGroups()` will set an empty list, and clear provgroups set before.

```go
// Good:
gos = keyhubmodel.NewGroupOnSystem()
gos.NoProvGroups()
pg := keyhubmodel.NewProvisioningGroup()
pg.Group = tmpgrp1.AsPrimer()
gos.AddProvGroup(*pg)

// Wrong:
gos = keyhubmodel.NewGroupOnSystem()
pg := keyhubmodel.NewProvisioningGroup()
pg.Group = tmpgrp1.AsPrimer()
gos.AddProvGroup(*pg)
gos.NoProvGroups() // This will clear the provgroups 

```