### PR TITLE
Feature/14 create a launchpadtile

### DIFF
--- a/keyhub.go
+++ b/keyhub.go
@@ -45,6 +45,7 @@ type Client struct {
 	Systems            *SystemService
 	ClientApplications *ClientApplicationService
 	Vaults             *VaultService
+	LaunchPadTile      *LaunchPadTileService
 }
 
 func NewClientDefault(issuer string, clientID string, clientSecret string) (*Client, error) {
@@ -120,6 +121,7 @@ func NewClient(httpClient *http.Client, issuer string, clientID string, clientSe
 		ClientApplications: newClientApplicationService(oauth2Sling.New()),
 		Groups:             newGroupService(oauth2Sling.New()),
 		Systems:            newSystemService(oauth2Sling.New()),
+		LaunchPadTile:      newLaunchPadTileService(oauth2Sling.New()),
 		Vaults:             newVaultService(versionedSling.New().Client(vaultClient)),
 	}, nil
 }

--- a/launchpadtile.go
+++ b/launchpadtile.go
@@ -95,7 +95,7 @@ func (s *LaunchPadTileService) GetById(id int64) (result *model.LaunchPadTile, e
 
 	_, err = s.sling.New().Get(idString).Receive(al, errorReport)
 	if errorReport.Code > 0 {
-		err = errorReport.Wrap("Could not get LaunchPadTile %q. Error: %s", idString)
+		err = errorReport.Wrap("Could not get LaunchPadTile %q. Error: %s", idString, errorReport.Message)
 		return
 	}
 	if err == nil && al == nil {
@@ -114,7 +114,7 @@ func (s *LaunchPadTileService) DeleteById(id int64) (err error) {
 
 	_, err = s.sling.New().Delete(idString).Receive(al, errorReport)
 	if errorReport.Code > 0 {
-		err = errorReport.Wrap("Could not delete LaunchPadTile %q. Error: %s", idString)
+		err = errorReport.Wrap("Could not delete LaunchPadTile %q. Error: %s", idString, errorReport.Message)
 		return
 	}
 	if err == nil && al == nil {

--- a/launchpadtile.go
+++ b/launchpadtile.go
@@ -1,0 +1,103 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package keyhub
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/dghubble/sling"
+	"github.com/topicuskeyhub/go-keyhub/model"
+)
+
+// LaunchPadTileService Service to manage launch pad tiles in keyhub
+type LaunchPadTileService struct {
+	sling *sling.Sling
+}
+
+func newLaunchPadTileService(sling *sling.Sling) *LaunchPadTileService {
+	return &LaunchPadTileService{
+		sling: sling.Path("/keyhub/rest/v1/launchpadtile/"),
+	}
+}
+
+// Create a new launch pad tile in Keyhub
+func (s *LaunchPadTileService) Create(tile *model.LaunchPadTile) (result *model.LaunchPadTile, err error) {
+
+	tiles := new(model.LaunchPadTileList)
+	results := new(model.LaunchPadTileList)
+	errorReport := new(model.ErrorReport)
+	tiles.Items = append(tiles.Items, *tile)
+
+	_, err = s.sling.New().Post("").BodyJSON(tiles).Receive(results, errorReport)
+	if errorReport.Code > 0 {
+		err = fmt.Errorf("Could not create LaunchPadTile. Error: %s", errorReport.Message)
+	}
+	if err == nil {
+		if len(results.Items) > 0 {
+			result = &results.Items[0]
+		} else {
+			err = fmt.Errorf("Created LaunchPadTile not found")
+		}
+	}
+
+	return
+}
+
+// List all available launch pad tiles.
+func (s *LaunchPadTileService) List() (tiles []model.LaunchPadTile, err error) {
+	searchRange := model.NewRange()
+
+	var response *http.Response
+
+	for ok := true; ok; ok = searchRange.NextPage() {
+
+		errorReport := new(model.ErrorReport)
+		results := new(model.LaunchPadTileList)
+		response, err = s.sling.New().Get("").Add(searchRange.GetRequestRangeHeader()).Add(searchRange.GetRequestModeHeader()).Receive(results, errorReport)
+		searchRange.ParseResponse(response)
+
+		if errorReport.Code > 0 {
+			err = fmt.Errorf("Could not get LaunchPadTiles. Error: %s", errorReport.Message)
+		}
+		if err == nil {
+			if len(results.Items) > 0 {
+				tiles = append(tiles, results.Items...)
+			}
+		}
+	}
+	return
+}
+
+// GetById Retrieve a launch pad tile by keyhub id
+func (s *LaunchPadTileService) GetById(id int64) (result *model.LaunchPadTile, err error) {
+	al := new(model.LaunchPadTile)
+	errorReport := new(model.ErrorReport)
+	idString := strconv.FormatInt(id, 10)
+
+	_, err = s.sling.New().Get(idString).Receive(al, errorReport)
+	if errorReport.Code > 0 {
+		err = fmt.Errorf("Could not get LaunchPadTile %q. Error: %s", idString, errorReport.Message)
+		return
+	}
+	if err == nil && al == nil {
+		err = fmt.Errorf("LaunchPadTile %q not found", idString)
+		return
+	}
+
+	return al, nil
+}

--- a/launchpadtile.go
+++ b/launchpadtile.go
@@ -45,13 +45,13 @@ func (s *LaunchPadTileService) Create(tile *model.LaunchPadTile) (result *model.
 
 	_, err = s.sling.New().Post("").BodyJSON(tiles).Receive(results, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not create LaunchPadTile. Error: %s", errorReport.Message)
+		err = errorReport.Wrap("Could not create LaunchPadTile.")
 	}
 	if err == nil {
 		if len(results.Items) > 0 {
 			result = &results.Items[0]
 		} else {
-			err = fmt.Errorf("Created LaunchPadTile not found")
+			err = fmt.Errorf("created LaunchPadTile not found")
 		}
 	}
 
@@ -72,7 +72,7 @@ func (s *LaunchPadTileService) List() (tiles []model.LaunchPadTile, err error) {
 		searchRange.ParseResponse(response)
 
 		if errorReport.Code > 0 {
-			err = fmt.Errorf("Could not get LaunchPadTiles. Error: %s", errorReport.Message)
+			err = errorReport.Wrap("Could not get LaunchPadTiles")
 		}
 		if err == nil {
 			if len(results.Items) > 0 {
@@ -91,7 +91,7 @@ func (s *LaunchPadTileService) GetById(id int64) (result *model.LaunchPadTile, e
 
 	_, err = s.sling.New().Get(idString).Receive(al, errorReport)
 	if errorReport.Code > 0 {
-		err = fmt.Errorf("Could not get LaunchPadTile %q. Error: %s", idString, errorReport.Message)
+		err = errorReport.Wrap("Could not get LaunchPadTile %q. Error: %s", idString)
 		return
 	}
 	if err == nil && al == nil {

--- a/model/launchpad.go
+++ b/model/launchpad.go
@@ -1,0 +1,91 @@
+package model
+
+const (
+	LAUNCHPAD_TYPE_MANUAL = LaunchpadTileType("MANUAL")
+	LAUNCHPAD_TYPE_SSO    = LaunchpadTileType("SSO_APPLICATION")
+	LAUNCHPAD_TYPE_RECORD = LaunchpadTileType("VAULT_RECORD")
+)
+
+type LaunchpadTileType string
+
+func NewLaunchPadTile(tiletype LaunchpadTileType) *LaunchPadTile {
+
+	t := new(LaunchPadTile)
+	t.DType = "launchpad.LaunchPadTile"
+
+	switch tiletype {
+	case LAUNCHPAD_TYPE_SSO:
+		t.DType = "launchpad.SsoApplicationLaunchpadTile"
+	case LAUNCHPAD_TYPE_RECORD:
+		t.DType = "launchpad.VaultRecordLaunchpadTile"
+	case LAUNCHPAD_TYPE_MANUAL:
+		t.DType = "launchpad.ManualLaunchpadTile"
+	}
+
+	return t
+
+}
+
+type LaunchPadTileList struct {
+	DType string          `json:"$type,omitempty"`
+	Items []LaunchPadTile `json:"items"`
+}
+
+type LaunchPadTilePrimer struct {
+	Linkable
+	DType string `json:"$type,omitempty"`
+}
+
+type LaunchPadTile struct {
+	LaunchPadTilePrimer
+	DType string `json:"$type,omitempty"`
+
+	Type          LaunchpadTileType  `json:"type"`
+	IdenticonCode int32              `json:"identiconCode"`
+	Logo          []byte             `json:"logo,omitempty"`
+	Group         *Group             `json:"group,omitempty"`
+	Application   *ClientApplication `json:"application,omitempty"`
+	VaultRecord   *VaultRecord       `json:"vaultRecord,omitempty"`
+}
+
+// AsPrimer Return LaunchPadTile with only Primer data
+func (t *LaunchPadTile) AsPrimer() *LaunchPadTile {
+	tile := &LaunchPadTile{}
+	tile.LaunchPadTilePrimer = t.LaunchPadTilePrimer
+	return tile
+}
+
+// ToPrimer Convert to LaunchPadTilePrimer
+func (t *LaunchPadTile) ToPrimer() *LaunchPadTilePrimer {
+	tile := t.LaunchPadTilePrimer
+	return &tile
+}
+
+/*
+launchpad_LaunchpadTile	{…}
+launchpad_LaunchpadTilePrimer	{…}
+launchpad_VaultRecordLaunchpadTile	{…}
+launchpad_SsoApplicationLaunchpadTile
+LinkableWrapper.launchpad_LaunchpadTile
+launchpad_DisplayedLaunchpadTile
+launchpad_DisplayedLaunchpadTiles
+launchpad_ManualLaunchpadTile
+*/
+
+type LaunchPadTileVaultRecord struct {
+	LaunchPadTile
+	DType string `json:"$type,omitempty"`
+}
+
+type LaunchPadTileSsoApplication struct {
+	LaunchPadTile
+	DType string `json:"$type,omitempty"`
+	Uri   string `json:"uri"`
+}
+
+type LaunchPadTileManual struct {
+	LaunchPadTile
+	DType string `json:"$type,omitempty"`
+	Uri   string `json:"uri"`
+	Title string `json:"title"`
+}

--- a/model/launchpad.go
+++ b/model/launchpad.go
@@ -159,6 +159,7 @@ type LaunchPadTileQueryParams struct {
 	Application   int64       `url:"application,omitempty"`
 	Group         int64       `url:"group,omitempty"`
 	Title         string      `url:"title,omitempty"`
+	VaultRecord   int64       `url:"vaultRecord,omitempty"`
 	VaultRecords  []int64     `url:"vaultRecord,omitempty"`
 }
 


### PR DESCRIPTION
This PR will add the ability to create LaunchPadTiles

```golang
grp, _ := client.Groups.GetByUUID(uuid.MustParse("00000000-0000-0000-0000-000000000000"))
vr, _ := client.Vaults.GetByUUID(grp, uuid.MustParse("00000000-0000-0000-0000-000000000000"), nil)
app, _ := client.ClientApplications.GetByUUID(uuid.MustParse("00000000-0000-0000-0000-000000000000"))

recordTile := model.NewVaultRecordLaunchPadTile(vr)
manualTile := model.NewManualLaunchPadTile("title", "https://localhost", grp)
applicationTile := model.NewApplicationLaunchPadTile("https://localhost22", app)

result, err := client.LaunchPadTile.Create(recordTile)
if err != nil {
  var apiError model.KeyhubApiError
  if errors.As(err, &apiError) {
	  fmt.Println("ErrorReport: ", strings.Join(apiError.Report.StackTrace, "\n"))
  } else {
	  fmt.Println("Error: ", err.Error())
  }
}

# Delete launchpad tile
error := client.LaunchPadTile.DeleteById(result.Self().ID)


# No query params
list,error := client.LaunchPadTile.List(nil)

# Query by Group Id
queryParams := model.LaunchPadTileQueryParams{Group: grp.Self().ID, Additional: model.LaunchPadTileAdditionalQueryParams{Audit: true}}
_,_ := client.LaunchPadTile.List(&queryParams)

# Query by one or more VaultRecord
queryParams = model.LaunchPadTileQueryParams{VaultRecord: vr.Self().ID}
_,_ := client.LaunchPadTile.List(&queryParams)

# Query by more VaultRecord
queryParams = model.LaunchPadTileQueryParams{VaultRecords: []int64{vr.Self().ID, vr.Self().ID}}
_,_ := client.LaunchPadTile.List(&queryParams)


# Query by title exact match
queryParams = model.LaunchPadTileQueryParams{Title: "Launchpad Item"}
_,_ := client.LaunchPadTile.List(&queryParams)

```