### PR TITLE
feat: Optional services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Issue # : Optional services based on supported version of keyhub
+
 
 ## [1.3.2] - 2024-06-12
 ### Changed

--- a/version.go
+++ b/version.go
@@ -59,26 +59,27 @@ func (s *VersionService) Get() (v *model.VersionInfo, err error) {
 	return results, nil
 }
 
-func (s *VersionService) CheckAndUpdateVersionedSling(version int, base *sling.Sling) (headerVersion string, err error) {
+func (s *VersionService) CheckAndUpdateVersionedSling(version int, base *sling.Sling) (isSupported bool, err error) {
 
+	isSupported = false
+	var headerVersion string
 	if s.info == nil {
 		s.info, err = s.Get()
 		if err != nil {
-			return "", err
+			return
 		}
 	}
 
 	if version > 0 {
 
-		isContractVersionSupported := false
 		for _, contractVersion := range s.info.ContractVersions {
 			if version == contractVersion {
-				isContractVersionSupported = true
+				isSupported = true
 				break
 			}
 		}
-		if !isContractVersionSupported {
-			return "", fmt.Errorf("KeyHub %v does not support api contract version %v", s.info.KeyhubVersion, version)
+		if !isSupported {
+			return isSupported, fmt.Errorf("KeyHub %v does not support api contract version %v", s.info.KeyhubVersion, version)
 		}
 
 		headerVersion = fmt.Sprintf("%d", version)
@@ -89,5 +90,5 @@ func (s *VersionService) CheckAndUpdateVersionedSling(version int, base *sling.S
 	base.Set("Accept", fmt.Sprintf("%v;version=%s", mediatype, headerVersion))
 	base.Set("Content-Type", fmt.Sprintf("%v;version=%s", mediatype, headerVersion))
 
-	return
+	return isSupported, nil
 }


### PR DESCRIPTION
The available services will be based on supported contract version of keyhub.

version 60 must be supported for:
- Accounts
- ClientApplications
- Systems
- LaunchPadTile
- ServiceAccounts

version 71 must be supported for:
- Groups
- Vaults

if both are not supported NewClient() will throw a error.